### PR TITLE
Updated main page and made formatting of pages guideline compliant

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -11,15 +11,17 @@ it.
 This site is currently *WIP* and very incomplete, thus contributions are
 welcome!
 
-+
-IMPORTANT: This wiki is not endorsed by, does not have any connection to, and
+[IMPORTANT]
+This wiki is not endorsed by, does not have any connection to, and
 is not related in any way with another wiki found at
 https://wiki.osdev.org[wiki.osdev.org].
 
 == Contributing
 Before contributing to this wiki, you should read following pages:
+
 * xref:writer_tutorial.adoc[Writing a document], for a quick tutorial on how to
 write pages for this wiki.
+
 * xref:guidelines.adoc[Style guidelines], for rules on article structure,
 vocabulary, commit messages and much more.
 

--- a/index.adoc
+++ b/index.adoc
@@ -39,8 +39,6 @@ certify that you have the right to do so.
 
 === Toolchain
 
-* xref:clang.adoc[LLVM+Clang]
-
 * xref:visual_studio.adoc[Visual Studio]
 
 * xref:calling_conventions.adoc[Calling conventions]
@@ -52,8 +50,14 @@ certify that you have the right to do so.
 === Learning
 * xref:fundamentals.adoc[Computer science fundamentals]
 
+=== Bootloaders
+
+* xref:stivale.adoc[Stivale]
+
 == Todo
 
 * Welcome to the modern era
 
 * Stivale C# bare bones
+
+* LLVM + Clang

--- a/index.adoc
+++ b/index.adoc
@@ -1,35 +1,49 @@
 ---
-title: Main Page
-description: The place to start for Operating System Development in the 2020s.
+title: Main page
+description: The place to start for operating system development in the 2020s.
 ---
-= The New OSDev Wiki
 
-Welcome to osdev.wiki.
+Welcome to *osdev.wiki*!
 
-The goal of this wiki is to modernize the information found in the long-standing OSDev wiki found at https://wiki.osdev.org[wiki.osdev.org] and to decentralize it. It is currently *WIP* and *not ready* for use.
+The goal of this wiki is to modernize the information found in the long-standing
+OSDev wiki found at https://wiki.osdev.org[wiki.osdev.org] and to decentralize
+it.
+This site is currently *WIP* and very incomplete, thus contributions are
+welcome!
 
-This wiki is not endorsed by, does not have any connection to, and is not related in any way with another wiki found at https://wiki.osdev.org[wiki.osdev.org].
++ IMPORTANT
+This wiki is not endorsed by, does not have any connection to, and is not
+related in any way with another wiki found at
+https://wiki.osdev.org[wiki.osdev.org].
+
+== Contributing
+Before contributing to this wiki, you should read following pages:
+* xref:writer_tutorial.adoc[Writing a document], for a quick tutorial on how to
+write pages for this wiki.
+* xref:guidelines.adoc[Style guidelines], for rules on article structure,
+vocabulary, commit messages and much more.
+
++ IMPORTANT
+By submitting a contribution to this wiki, you irrevocably agree to release
+your contribution under the link:/licenses/CC0.txt[CC0 license] and certify
+that you have the right to do so.
 
 == Quick Access
-
-* About This Wiki
-* xref:time_travel.adoc[Welcome To the Modern Era]
-* Requirements
-
 === Tutorials
-
-* xref:stivale_barebones.adoc[Stivale C Bare Bones]
-* Stivale C# Bare Bones (unavailable)
-* xref:cross_clang.adoc[Cross Compiling using Clang]
+* xref:stivale_barebones.adoc[Stivale C bare bones]
+* xref:cross_clang.adoc[Cross compiling using Clang]
 
 === Toolchain
-
 * xref:clang.adoc[LLVM+Clang]
 * xref:visual_studio.adoc[Visual Studio]
-* xref:calling_conventions.adoc[Calling Conventions]
+* xref:calling_conventions.adoc[Calling conventions]
 
 === Hardware
 * xref:x86.adoc[x86]
 
 === Learning
-* xref:fundamentals.adoc[Computer Science Fundamentals]
+* xref:fundamentals.adoc[Computer science fundamentals]
+
+== Todo
+* Welcome to the modern era
+* Stivale C# bare bones

--- a/index.adoc
+++ b/index.adoc
@@ -25,39 +25,30 @@ write pages for this wiki.
 * xref:guidelines.adoc[Style guidelines], for rules on article structure,
 vocabulary, commit messages and much more.
 
-+
-IMPORTANT: By submitting a contribution to this wiki, you irrevocably agree to
-release your contribution under the link:/licenses/CC0.txt[CC0 license] and
-certify that you have the right to do so.
+[IMPORTANT]
+By submitting a contribution to this wiki, you irrevocably agree to release
+your contribution under the link:/licenses/CC0.txt[CC0 license] and certify
+that you have the right to do so.
 
 == Quick Access
 === Tutorials
-
 * xref:stivale_barebones.adoc[Stivale C bare bones]
-
 * xref:cross_clang.adoc[Cross compiling using Clang]
 
 === Toolchain
-
 * xref:visual_studio.adoc[Visual Studio]
-
 * xref:calling_conventions.adoc[Calling conventions]
 
 === Hardware
-
 * xref:x86.adoc[x86]
 
 === Learning
 * xref:fundamentals.adoc[Computer science fundamentals]
 
 === Bootloaders
-
 * xref:stivale.adoc[Stivale]
 
 == Todo
-
 * Welcome to the modern era
-
 * Stivale C# bare bones
-
 * LLVM + Clang

--- a/index.adoc
+++ b/index.adoc
@@ -11,9 +11,9 @@ it.
 This site is currently *WIP* and very incomplete, thus contributions are
 welcome!
 
-+ IMPORTANT
-This wiki is not endorsed by, does not have any connection to, and is not
-related in any way with another wiki found at
++
+IMPORTANT: This wiki is not endorsed by, does not have any connection to, and
+is not related in any way with another wiki found at
 https://wiki.osdev.org[wiki.osdev.org].
 
 == Contributing
@@ -23,27 +23,35 @@ write pages for this wiki.
 * xref:guidelines.adoc[Style guidelines], for rules on article structure,
 vocabulary, commit messages and much more.
 
-+ IMPORTANT
-By submitting a contribution to this wiki, you irrevocably agree to release
-your contribution under the link:/licenses/CC0.txt[CC0 license] and certify
-that you have the right to do so.
++
+IMPORTANT: By submitting a contribution to this wiki, you irrevocably agree to
+release your contribution under the link:/licenses/CC0.txt[CC0 license] and
+certify that you have the right to do so.
 
 == Quick Access
 === Tutorials
+
 * xref:stivale_barebones.adoc[Stivale C bare bones]
+
 * xref:cross_clang.adoc[Cross compiling using Clang]
 
 === Toolchain
+
 * xref:clang.adoc[LLVM+Clang]
+
 * xref:visual_studio.adoc[Visual Studio]
+
 * xref:calling_conventions.adoc[Calling conventions]
 
 === Hardware
+
 * xref:x86.adoc[x86]
 
 === Learning
 * xref:fundamentals.adoc[Computer science fundamentals]
 
 == Todo
+
 * Welcome to the modern era
+
 * Stivale C# bare bones

--- a/pages/calling_conventions.adoc
+++ b/pages/calling_conventions.adoc
@@ -1,5 +1,5 @@
 ---
-title: Calling conventions
+title: Calling conventions (x86)
 tags: assembly, x86, x64, sysv, msvc
 category: Assembly
 description: Examples of calling conventions on common platforms.
@@ -66,7 +66,7 @@ bytes below the caller's stack.
 
 ==== Parameters
 `RCX`/`XMM0`, `RDX`/`XMM1`, `R8`/`XMM2`, `R9`/`XMM3`, stack (`[RSP+0x20]`,
-`[RSP+0x28]` and so on, 0x20 is due to the home space being there).
+`[RSP+0x28]` and so on, 0x20 is due to the home space).
 
 For example, a function with the prototype 
 
@@ -82,7 +82,7 @@ parameters and home space and ensure that the stack is aligned after the `CALL`.
 
 ==== Return value
 If the return value is an integer/struct/union whose size is less than or equal
-than 64 bits, it is returned in RAX; otherwise, the struct is allocated by the
+to 64 bits, it is returned in RAX; otherwise, the struct is allocated by the
 caller and a pointer to it is passed as the first parameter.
 
 `LargeStruct DoSomething(int a)` 

--- a/pages/calling_conventions.adoc
+++ b/pages/calling_conventions.adoc
@@ -26,7 +26,7 @@ the Windows calling convention.
 
 === Microsoft x64
 
-The *x64 Application Binary Interface*footnote:[https://github.com/MicrosoftDocs/cpp-docs/blob/main/docs/build/x64-calling-convention.md]
+The x64 Application Binary Interfacefootnote:[https://github.com/MicrosoftDocs/cpp-docs/blob/main/docs/build/x64-calling-convention.md]
 (ABI) uses a four-register fast-call calling convention by default.
 Space is allocated on the call stack as a shadow store for callees to save
 those registers.

--- a/pages/calling_conventions.adoc
+++ b/pages/calling_conventions.adoc
@@ -1,31 +1,51 @@
 ---
-title: Calling Conventions
+title: Calling conventions
 tags: assembly, x86, x64, sysv, msvc
 category: Assembly
 description: Examples of calling conventions on common platforms.
 ---
 :source-language: c
 
-== What are calling conventions?
-A calling convention is the set of contracts that compiler-generated machine code respects and expects external functions to respect. The calling convention specifies, for example
+A *calling convention* is the set of contracts that compiler-generated machine
+code respects and expects external functions to respect.
+The calling convention specifies, for example
 
 - how parameters are passed to functions
-- how the stack is handled and cleaned (for example if needs to be aligned at function entry)
+
+- how the stack is handled and cleaned (for example if needs to be aligned at
+  function entry)
+
 - how structures are going to be laid out in memory
+
 - which registers need to be restored by the caller and which by the callee
 
 == x86-64 calling conventions
-The Windows (including UEFI) world and the UNIX (Linux, macOS, BSDs) world have adopted two different conventions. Note that MSVC can only generate code using the Windows calling convention.
+The Windows (including UEFI) world and the UNIX (Linux, macOS, BSDs) world have
+adopted two different conventions. Note that MSVC can only generate code using
+the Windows calling convention.
 
-=== Microsoft x64footnote:[https://github.com/MicrosoftDocs/cpp-docs/blob/main/docs/build/x64-calling-convention.md]
+=== Microsoft x64
 
-> The x64 Application Binary Interface (ABI) uses a four-register fast-call calling convention by default. Space is allocated on the call stack as a shadow store for callees to save those registers.
+The *x64 Application Binary Interface*footnote:[https://github.com/MicrosoftDocs/cpp-docs/blob/main/docs/build/x64-calling-convention.md]
+(ABI) uses a four-register fast-call calling convention by default.
+Space is allocated on the call stack as a shadow store for callees to save
+those registers.
 
-> There's a strict one-to-one correspondence between a function call's arguments and the registers used for those arguments. Any argument that doesn't fit in 8 bytes, or isn't 1, 2, 4, or 8 bytes, must be passed by reference. A single argument is never spread across multiple registers.
+There is a strict one-to-one correspondence between a function call's arguments
+and the registers used for those arguments.
+Any argument that does not fit in 8 bytes, or is not 1, 2, 4, or 8 bytes, must
+be passed by reference.
+A single argument is never spread across multiple registers.
 
-> The x87 register stack is unused. It may be used by the callee, but consider it volatile across function calls. All floating point operations are done using the 16 XMM registers.
+The x87 register stack is unused.
+It may be used by the callee, but consider it volatile across function calls.
+All floating point operations are done using the 16 XMM registers.
 
-> Integer arguments are passed in registers RCX, RDX, R8, and R9. Floating point arguments are passed in XMM0L, XMM1L, XMM2L, and XMM3L. 16-byte arguments are passed by reference. Parameter passing is described in detail in Parameter passing. These registers, and RAX, R10, R11, XMM4, and XMM5, are considered volatile.
+Integer arguments are passed in registers RCX, RDX, R8, and R9. Floating point
+arguments are passed in XMM0L, XMM1L, XMM2L, and XMM3L.
+16-byte arguments are passed by reference. Parameter passing is described in
+detail in Parameter passing.
+These registers, and RAX, R10, R11, XMM4, and XMM5, are considered volatile.
 
 ==== Register allocation
 
@@ -34,15 +54,24 @@ Caller-saved: RAX, RCX, RDX,  R8, R9, R10, R11
 Callee-saved: RBX, RBP, RDI, RSI, RSP, R12, R13, R14, R15
 
 ==== Stack
-The stack is always 16-byte aligned at function **entry**: this requires the stack to be **NOT** aligned to 16 bytes before the `CALL`, since the instruction pushes 8 bytes on the stack.
+The stack is always 16-byte aligned at _function entry_: this requires the
+stack to be aligned to 8 bytes, but _not_ 16 bytes, before the `CALL`, since
+the instruction pushes 8 bytes on the stack.
 
-All functions need to have 32 bytes of home space (also known as spill space or shadow space), which is allocated *before* pushing the other parameters on the stack. This allows for an easier implementation of variadic functions: `va_start` can just put the four register parameters in the home space such that `va_arg` simply becomes a lookup starting at RSP.
+All functions need to have 32 bytes of home space (also known as spill space or
+shadow space), which is allocated _before_ pushing the other parameters on the
+stack.
+This allows for an easier implementation of variadic functions: `va_start` can
+just put the four register parameters in the home space, so that `va_arg` simply
+becomes a lookup starting at RSP.
 
-For example, if the caller calls a function with 4 or 5 arguments, it needs to allocate 40 bytes of stack in order for the stack at the callee entry to be 48 bytes below the caller's stack.
-
+For example, if the caller calls a function with 4 or 5 arguments, it needs to
+allocate 40 bytes of stack in order for the stack at the callee entry to be 48
+bytes below the caller's stack.
 
 ==== Parameters
-`RCX`/`XMM0`, `RDX`/`XMM1`, `R8`/`XMM2`, `R9`/`XMM3`, stack (`[RSP+0x20]`, `[RSP+0x28]` and so on, 0x20 is due to the home space being there).
+`RCX`/`XMM0`, `RDX`/`XMM1`, `R8`/`XMM2`, `R9`/`XMM3`, stack (`[RSP+0x20]`,
+`[RSP+0x28]` and so on, 0x20 is due to the home space being there).
 
 For example, a function with the prototype 
 
@@ -51,25 +80,44 @@ For example, a function with the prototype
  void DoSomething(int a, float b, int c, int d, int e, float f);
 ----
 
-would pass parameters in RCX, XMM1, R8, R9, [RSP+0x20] and [RSP+0x28] respectively. A function calling this needs to have at least 56 bytes of stack to store the parameters and home space and ensure that the stack is aligned after the `CALL`.
+would pass parameters in RCX, XMM1, R8, R9, [RSP+0x20] and [RSP+0x28]
+respectively.
+A function calling this needs to have at least 56 bytes of stack to store the
+parameters and home space and ensure that the stack is aligned after the `CALL`.
 
 ==== Return value
-If the return value is an integer/struct/union whose size is less than or equal than 64 bits, it's returned in RAX; otherwise, the struct is allocated by the caller and a pointer to it is passed as the first parameter.
+If the return value is an integer/struct/union whose size is less than or equal
+than 64 bits, it is returned in RAX; otherwise, the struct is allocated by the
+caller and a pointer to it is passed as the first parameter.
 
 `LargeStruct DoSomething(int a)` 
 actually becomes 
 `void DoSomething(LargeStruct *ret, int a)`.
 
-=== System Vfootnote:[https://raw.githubusercontent.com/wiki/hjl-tools/x86-psABI/x86-64-psABI-1.0.pdf]
+=== System V
 
-> The standard calling sequence requirements apply only to global functions. Local functions that are not reachable from other compilation units may use different conventions. Nevertheless, it is recommended that all functions use the standard calling sequence when possible.
+The standard calling sequence requirementsfootnote:[https://raw.githubusercontent.com/wiki/hjl-tools/x86-psABI/x86-64-psABI-1.0.pdf]
+apply only to global functions.
+Local functions that are not reachable from other compilation units may use
+different conventions.
+Nevertheless, it is recommended that all functions use the standard calling
+sequence when possible.
 
-> The CPU shall be in x87 mode upon entry to a function. Therefore, every function that uses the MMX registers is required to issue an EMMS or FEMMS instruction after using MMX registers, before returning or calling another function.
+The CPU shall be in x87 mode upon entry to a function.
+Therefore, every function that uses the MMX registers is required to issue an
+EMMS or FEMMS instruction after using MMX registers, before returning or calling
+another function.
 
-> The direction flag DF in the RFLAGS register must be clear (set to “forward” direction) on function entry and return. Other user flags have no specified role in the standard calling sequence and are not preserved across calls.
+The direction flag DF in the RFLAGS register must be clear (set to "forward"
+direction) on function entry and return.
+Other user flags have no specified role in the standard calling sequence and are
+not preserved across calls.
 
-> Registers RBP, RBX and
-R12 through R15 “belong” to the calling function and the called function is required to preserve their values. In other words, a called function must preserve these registers’ values for its caller. Remaining registers “belong” to the called function.
+Registers RBP, RBX and R12 through R15 "belong" to the calling function and the
+called function is required to preserve their values.
+In other words, a called function must preserve these registers’ values for its
+caller.
+Remaining registers "belong" to the called function.
 
 ==== Register allocation
 
@@ -78,21 +126,32 @@ Caller-saved: RAX, RCX, RDX, RDI, RSI, R8, R9, R10, R11
 Callee-saved: RBX, RBP, RSP R12, R13, R14, R15
 
 ==== Stack
-The stack is always 16-byte aligned at function **call**: this requires the stack to be aligned to 16 bytes before the `CALL`. The push of the return address onto the stack by `CALL` is immediately succeeded by the push of RBP onto the stack by the callee function, thereby re-aligning the stack shortly after function entry.
+The stack is always 16-byte aligned at function **call**: this requires the
+stack to be aligned to 16 bytes before the `CALL`.
+The push of the return address onto the stack by `CALL` is immediately succeeded
+by the push of RBP onto the stack by the callee function, thereby re-aligning
+the stack shortly after function entry.
 
 ==== Parameters
-`RDI`, `RSI`, `RDX`, `RCX`, `R8`, `R9`, stack (`[RSP+0x00]`, `[RSP+0x08]` and so on).
+`RDI`, `RSI`, `RDX`, `RCX`, `R8`, `R9`, stack (`[RSP+0x00]`, `[RSP+0x08]` and so
+on).
 
-If the parameter is of type `float` or `double`, it will be stored in the next available SSE register (`XMM0`-`XMM7`).
+If the parameter is of type `float` or `double`, it will be stored in the next
+available SSE register (`XMM0`-`XMM7`).
 
-For example, a function with the prototype `void DoSomething(int a, float b, int c, int d, int e, float f)` would pass parameters in `RDI`, `XMM0`, `R8`, `R9`, `[RSP+0x00]` and `XMM1` respectively. A function calling this needs to have at least 32 bytes of stack to store the parameters and align the stack upon call.
+For example, a function with the prototype
+`void DoSomething(int a, float b, int c, int d, int e, float f)` would pass
+parameters in `RDI`, `XMM0`, `R8`, `R9`, `[RSP+0x00]` and `XMM1` respectively.
+A function calling this needs to have at least 32 bytes of stack to store the
+parameters and align the stack upon call.
 
 ==== Return value
-If the return value is an integer/struct/union whose size is less than or equal than 64 bits, it's returned in `RAX`; otherwise, the struct is allocated by the caller and a pointer to it is passed as the first parameter, similarly to the Microsoft x64 ABI. Dissimilarly, the pointer is actually returned in `RAX` upon return.
+If the return value is an integer/struct/union whose size is less than or equal
+than 64 bits, it is returned in `RAX`; otherwise, the struct is allocated by the
+caller and a pointer to it is passed as the first parameter, similarly to the
+Microsoft x64 ABI.
+Dissimilarly, the pointer is actually returned in `RAX` upon return.
 
 `LargeStruct DoSomething(int a)`
 actually becomes 
 `LargeStruct* DoSomething(LargeStruct *ret, int a)`.
-
-=== See Also
-

--- a/pages/calling_conventions.adoc
+++ b/pages/calling_conventions.adoc
@@ -1,5 +1,5 @@
 ---
-title: Calling conventions (x86)
+title: Calling conventions
 tags: assembly, x86, x64, sysv, msvc
 category: Assembly
 description: Examples of calling conventions on common platforms.
@@ -44,9 +44,15 @@ detail in Parameter passing.
 These registers, and RAX, R10, R11, XMM4, and XMM5, are considered volatile.
 
 ==== Register allocation
-Caller-saved: RAX, RCX, RDX,  R8, R9, R10, R11
+[cols="1,1"]
+|===
 
-Callee-saved: RBX, RBP, RDI, RSI, RSP, R12, R13, R14, R15
+| Caller saved
+| RAX, RCX, RDX,  R8, R9, R10, R11
+
+| Callee saved
+| RBX, RBP, RDI, RSI, RSP, R12, R13, R14, R15
+|===
 
 ==== Stack
 The stack is always 16-byte aligned at _function entry_: this requires the
@@ -72,7 +78,7 @@ For example, a function with the prototype
 
 [source,c]
 ----
- void DoSomething(int a, float b, int c, int d, int e, float f);
+ void do_something(int a, float b, int c, int d, int e, float f);
 ----
 
 would pass parameters in RCX, XMM1, R8, R9, [RSP+0x20] and [RSP+0x28]
@@ -85,9 +91,13 @@ If the return value is an integer/struct/union whose size is less than or equal
 to 64 bits, it is returned in RAX; otherwise, the struct is allocated by the
 caller and a pointer to it is passed as the first parameter.
 
-`LargeStruct DoSomething(int a)` 
-actually becomes 
-`void DoSomething(LargeStruct *ret, int a)`.
+[source,c]
+---
+ // large_struct_t is larger than 64 bits, this:
+ large_struct_t do_something(int a)
+ // effectively becomes this:
+ void do_something(large_struct_t *ret, int a)
+---
 
 === System V
 The standard calling sequence requirementsfootnote:[https://raw.githubusercontent.com/wiki/hjl-tools/x86-psABI/x86-64-psABI-1.0.pdf]
@@ -114,9 +124,15 @@ caller.
 Remaining registers "belong" to the called function.
 
 ==== Register allocation
-Caller-saved: RAX, RCX, RDX, RDI, RSI, R8, R9, R10, R11
+[cols="1,1"]
+|===
 
-Callee-saved: RBX, RBP, RSP R12, R13, R14, R15
+| Caller saved
+| RAX, RCX, RDX, RDI, RSI, R8, R9, R10, R11
+
+| Callee saved
+| RBX, RBP, RSP, R12, R13, R14, R15
+|===
 
 ==== Stack
 The stack is always 16-byte aligned at function _call_: this requires the
@@ -133,7 +149,7 @@ If the parameter is of type `float` or `double`, it will be stored in the next
 available SSE register (`XMM0`-`XMM7`).
 
 For example, a function with the prototype
-`void DoSomething(int a, float b, int c, int d, int e, float f)` would pass
+`void do_something(int a, float b, int c, int d, int e, float f)` would pass
 parameters in `RDI`, `XMM0`, `R8`, `R9`, `[RSP+0x00]` and `XMM1` respectively.
 A function calling this needs to have at least 32 bytes of stack to store the
 parameters and align the stack upon call.
@@ -145,6 +161,10 @@ caller and a pointer to it is passed as the first parameter, similarly to the
 Microsoft x64 ABI.
 Dissimilarly, the pointer is actually returned in `RAX` upon return.
 
-`LargeStruct DoSomething(int a)`
-actually becomes 
-`LargeStruct* DoSomething(LargeStruct *ret, int a)`.
+[source,c]
+---
+ // large_struct_t is larger than 64 bits, this:
+ large_struct_t do_something(int a)
+ // effectively becomes this:
+ void do_something(large_struct_t *ret, int a)
+---

--- a/pages/calling_conventions.adoc
+++ b/pages/calling_conventions.adoc
@@ -126,7 +126,7 @@ Caller-saved: RAX, RCX, RDX, RDI, RSI, R8, R9, R10, R11
 Callee-saved: RBX, RBP, RSP R12, R13, R14, R15
 
 ==== Stack
-The stack is always 16-byte aligned at function **call**: this requires the
+The stack is always 16-byte aligned at function _call_: this requires the
 stack to be aligned to 16 bytes before the `CALL`.
 The push of the return address onto the stack by `CALL` is immediately succeeded
 by the push of RBP onto the stack by the callee function, thereby re-aligning

--- a/pages/calling_conventions.adoc
+++ b/pages/calling_conventions.adoc
@@ -11,12 +11,9 @@ code respects and expects external functions to respect.
 The calling convention specifies, for example
 
 - how parameters are passed to functions
-
 - how the stack is handled and cleaned (for example if needs to be aligned at
   function entry)
-
 - how structures are going to be laid out in memory
-
 - which registers need to be restored by the caller and which by the callee
 
 == x86-64 calling conventions
@@ -25,7 +22,6 @@ adopted two different conventions. Note that MSVC can only generate code using
 the Windows calling convention.
 
 === Microsoft x64
-
 The x64 Application Binary Interfacefootnote:[https://github.com/MicrosoftDocs/cpp-docs/blob/main/docs/build/x64-calling-convention.md]
 (ABI) uses a four-register fast-call calling convention by default.
 Space is allocated on the call stack as a shadow store for callees to save
@@ -48,7 +44,6 @@ detail in Parameter passing.
 These registers, and RAX, R10, R11, XMM4, and XMM5, are considered volatile.
 
 ==== Register allocation
-
 Caller-saved: RAX, RCX, RDX,  R8, R9, R10, R11
 
 Callee-saved: RBX, RBP, RDI, RSI, RSP, R12, R13, R14, R15
@@ -95,7 +90,6 @@ actually becomes
 `void DoSomething(LargeStruct *ret, int a)`.
 
 === System V
-
 The standard calling sequence requirementsfootnote:[https://raw.githubusercontent.com/wiki/hjl-tools/x86-psABI/x86-64-psABI-1.0.pdf]
 apply only to global functions.
 Local functions that are not reachable from other compilation units may use
@@ -120,7 +114,6 @@ caller.
 Remaining registers "belong" to the called function.
 
 ==== Register allocation
-
 Caller-saved: RAX, RCX, RDX, RDI, RSI, R8, R9, R10, R11
 
 Callee-saved: RBX, RBP, RSP R12, R13, R14, R15

--- a/pages/cross_clang.adoc
+++ b/pages/cross_clang.adoc
@@ -1,59 +1,100 @@
 ---
-title: clang Cross-Compiler
+title: Clang cross compiler
 tags: compiler, clang, tutorial
 category: Tutorial
-description: Tutorial on how to setup cross-compilation for OS development using clang.
+description: Tutorial on how to setup cross compilation for OS development using Clang.
 ---
 
-== Introduction
-
-A https://en.wikipedia.org/wiki/Cross_compiler[cross compiler] is a compiler that runs on platform A (the **host**), but generates executable code for platform B (the **target**). The platforms do not need to but usually differ in CPU architecture, library environment, xref:calling_conventions.adoc[ABI], and/or xref:executable_format.adoc[executable format]. For operating system development, the host is our development system, and the target is the developed OS. It is important to realize that these two platforms are not the same: the developed OS will always differ from the development OS. Thus it is necessary to use a cross compiler to avoid various troubles down the road.
+A https://en.wikipedia.org/wiki/Cross_compiler[*cross compiler*] is a compiler
+generates a code for a different platform (the **target**) than platform it
+runs on (the **host**).
+The platforms may differ in CPU architecture, library environment,
+xref:calling_conventions.adoc[ABI], and executable format.
+For operating system development, the host is our development system, and the
+target is the developed OS.
+It is important to realize that these two platforms are not the same: the
+developed OS will always differ from the development OS.
+Thus it is necessary to use a cross compiler to avoid various troubles down the
+road.
 
 == Why is cross-compilation necessary?
+Unless development is being done on the OS being developed, a cross compiler is
+necessary.
+The compiler must know the correct target platform, otherwise there will be
+issues, if not now then later.
+If the system compiler is used, it will not know that it is not targeting the
+host OS: it compiles something else entirely.
+Some tutorials suggest using the system compiler, and passing it several
+options to tell it that it is not targetting the host.
+This is not sustainable in the long run and the real solution is to use a
+cross-compiler.
 
-Unless development is being done on your developed OS, a cross compiler is necessary. The compiler must know the correct target platform, otherwise there will be issues, if not now then later. If the system compiler is used, it will not know that it is not targeting your host OS: it compiling something else entirely. Some tutorials suggest using the system compiler, and passing it several options to tell it that it's not targetting the host. This is not sustainable in the long run and the real solution is to use a cross-compiler. Further argumentation for using a cross compiler, if this wasn't convincing enough, can be found in the article xref:why_cross_compile.adoc[]
-
-== What is clang?
-
-As an operating system developer in the 2020s, xref:time_travel.adoc[newer technologies] have been developed that not only simplify the development process, but are of higher quality and are more powerful than what was used before. One of these technologies is https://llvm.org[LLVM]. Most osdev guides, including the original https://wiki.osdev.org[osdev.org wiki] instruct the developer to use GCC. Using LLVM+clang makes the life of an OS developer easier at the beginning, because unlike GCC, this compiler was designed to cross-compile from the very beginning, and thus it is not neccessary to build an entire toolchain from scratch for each desired target platform. It is also the native compiler on BSD and Mac OS X systems. The error messages are more accurate and informational. The main drawbacks is that when adding support for your custom platform is slower, as LLVM is much larger and slower to compile. GCC also compiles code faster. Ultimately, the compiler you use doesn't matter too much.
+== What is Clang?
+As an operating system developer in the 2020s, newer technologies have been
+developed that not only simplify the development process, but are of higher
+quality and are more powerful than what was used before.
+One of these technologies is https://llvm.org[LLVM].
+Most osdev guides instruct the developer to use GCC.
+Using LLVM+Clang makes the life of an OS developer easier at the beginning,
+because unlike GCC, this compiler was designed to cross-compile from the very
+beginning, and thus it is not neccessary to build an entire toolchain from
+scratch for each desired target platform.
+It is also the native compiler on BSD and Mac OS X systems.
+The error messages are more accurate and informational.
+The main drawbacks is that when adding support for your custom platform is
+slower, as LLVM is much larger and slower to compile.
+GCC also compiles code faster.
+Ultimately, the compiler you use does not matter too much.
 
 == Targets
-Cross compilation is done using a xref:target_triplet.adoc[], which conveys information to the compiler about the platform that is being compiled to.
+Cross compilation is done using a target triplet, which conveys information to
+the compiler about the platform that is being compiled to.
 
 == Start
-
-Install clang on the host system. It is the standard compiler on BSD-like systems, and virtually all Linux distributions have clang packaged in their software repositories. There is an installer for Windows.
+Install Clang on the host system.
+It is the standard compiler on BSD-like systems, and virtually all Linux
+distributions have Clang packaged in their software repositories.
+There is an installer for Windows.
 
 === Linux
+Install Clang through the distribution package manager:
 
-Install clang through the distribution package manager:
+* Ubuntu-based: `# apt install Clang`
+* Arch-based: `# pacman -S Clang`
+* Fedora: `# dnf install Clang`
+* Gentoo: `# emerge -a Clang`
+  - Be sure to enable the target architecture(s) in the LLVM_TARGETS variable
+    in /etc/portage/make.conf
+* Alpine: `# apk add Clang`
+* Others: It is highly unlikely the distribution does not provide Clang
+  packaged.
+  Search the repositories.
 
-* Ubuntu-based: `# apt install clang`
-* Arch-based: `# pacman -S clang`
-* Fedora: `# dnf install clang`
-* Gentoo: `# emerge -a clang`
-  - Be sure to enable the target architecture(s) in the LLVM_TARGETS variable in /etc/portage/make.conf
-* Alpine: `# apk add clang`
-* Others: It is highly unlikely the distribution does not provide clang packaged. Search the repositories.
-
-In the case that clang isn't packaged, it can be built from source.
+In the case that Clang isn't packaged, it can be built from source.
 
 === Windows
+If xref:visual_studio.adoc[Visual Studio] with the "Desktop Development with
+C++" toolset is installed, Clang can be installed as an individual component
+through the Visual Studio Installer.
+See https://docs.microsoft.com/en-us/cpp/build/clang-support-msbuild?view=msvc-170[Clang/LLVM support in Visual Studio].
 
-If xref:visual_studio.adoc[Visual Studio] with the "Desktop Development with C++" toolset is installed, clang can be installed as an individual component through the Visual Studio Installer. See https://docs.microsoft.com/en-us/cpp/build/clang-support-msbuild?view=msvc-170[Clang/LLVM support in Visual Studio].as
-
-If Visual Studio is not desired or installed, the latest release of clang can be installed from the https://github.com/llvm/llvm-project/releases[LLVM GitHub release page].
+If Visual Studio is not desired or installed, the latest release of Clang can
+be installed from the
+https://github.com/llvm/llvm-project/releases[LLVM GitHub release page].
 
 TODO: Windows
 
 === *BSD
-
-Clang is the default compiler for OpenBSD, NetBSD and FreeBSD, so it should be pre-installed.
+Clang is the default compiler for OpenBSD, NetBSD and FreeBSD, so it should be
+pre-installed.
 
 === macOS
-
-The built-in apple clang comes crippled: it only ships with x86_64 and arm64 support (but still supports ELF). It is recommended to get clang from https://brew.sh[homebrew], as the LLVM linker (lld) is needed to get anything meaningful done either way. It is also worth noting that proper cross-compilation GCC tools are also in the homebrew repositories (under the names x86_64-elf-binutils and x86_64-elf-gcc).
+The built-in apple Clang comes crippled: it only ships with x86_64 and arm64
+support (but still supports ELF).
+It is recommended to get Clang from https://brew.sh[homebrew], as the LLVM
+linker (lld) is needed to get anything meaningful done either way.
+It is also worth noting that proper cross-compilation GCC tools are also in the
+homebrew repositories (under the names x86_64-elf-binutils and x86_64-elf-gcc).
 
 == Enabling cross-compilation
-
 TODO

--- a/pages/cross_clang.adoc
+++ b/pages/cross_clang.adoc
@@ -35,7 +35,7 @@ developed that not only simplify the development process, but are of higher
 quality and are more powerful than what was used before.
 One of these technologies is https://llvm.org[LLVM].
 Most osdev guides instruct the developer to use GCC.
-Using LLVM+Clang makes the life of an OS developer easier at the beginning,
+Using LLVM and Clang makes the life of an OS developer easier at the beginning,
 because unlike GCC, this compiler was designed to cross-compile from the very
 beginning, and thus it is not neccessary to build an entire toolchain from
 scratch for each desired target platform.
@@ -59,13 +59,13 @@ There is an installer for Windows.
 === Linux
 Install Clang through the distribution package manager:
 
-* Ubuntu-based: `# apt install Clang`
-* Arch-based: `# pacman -S Clang`
-* Fedora: `# dnf install Clang`
-* Gentoo: `# emerge -a Clang`
+* Ubuntu-based: `# apt install clang`
+* Arch-based: `# pacman -S clang`
+* Fedora: `# dnf install clang`
+* Gentoo: `# emerge -a clang`
   - Be sure to enable the target architecture(s) in the LLVM_TARGETS variable
     in /etc/portage/make.conf
-* Alpine: `# apk add Clang`
+* Alpine: `# apk add clang`
 * Others: It is highly unlikely the distribution does not provide Clang
   packaged.
   Search the repositories.
@@ -82,7 +82,7 @@ If Visual Studio is not desired or installed, the latest release of Clang can
 be installed from the
 https://github.com/llvm/llvm-project/releases[LLVM GitHub release page].
 
-TODO: Windows
+// TODO: Windows
 
 === *BSD
 Clang is the default compiler for OpenBSD, NetBSD and FreeBSD, so it should be
@@ -94,7 +94,7 @@ support (but still supports ELF).
 It is recommended to get Clang from https://brew.sh[homebrew], as the LLVM
 linker (lld) is needed to get anything meaningful done either way.
 It is also worth noting that proper cross-compilation GCC tools are also in the
-homebrew repositories (under the names x86_64-elf-binutils and x86_64-elf-gcc).
+Homebrew repositories (under the names x86_64-elf-binutils and x86_64-elf-gcc).
 
-== Enabling cross-compilation
-TODO
+// == Enabling cross-compilation
+// TODO

--- a/pages/cross_clang.adoc
+++ b/pages/cross_clang.adoc
@@ -91,7 +91,7 @@ pre-installed.
 === macOS
 The built-in apple Clang comes crippled: it only ships with x86_64 and arm64
 support (but still supports ELF).
-It is recommended to get Clang from https://brew.sh[homebrew], as the LLVM
+It is recommended to get Clang from https://brew.sh[Homebrew], as the LLVM
 linker (lld) is needed to get anything meaningful done either way.
 It is also worth noting that proper cross-compilation GCC tools are also in the
 Homebrew repositories (under the names x86_64-elf-binutils and x86_64-elf-gcc).

--- a/pages/guidelines.adoc
+++ b/pages/guidelines.adoc
@@ -182,7 +182,7 @@ NOTE: C is the _lingua franca_ of programming languages and _the_ generic
 ** Possessive forms of nouns are formed by using -'s.
 +
 IMPORTANT: "It" is not a noun, but a personal pronoun.
-The corresponding possessive pronoun is "its", not "it's".
+           The corresponding possessive pronoun is "its", not "it's".
 
 ** Use the present tense by default.
 

--- a/pages/guidelines.adoc
+++ b/pages/guidelines.adoc
@@ -310,8 +310,8 @@ Syntax Quick reference] as well as the more broad
 https://docs.asciidoctor.org/asciidoc/latest/[AsciiDoc Language Documentation].
 
 A useful tool for formatting your AsciiDoc is
-https://www.nicemice.net/par/[`par`], though as it's not specific to AsciiDoc,
-it will break formatting elements.
+https://www.nicemice.net/par/[`par`], although, as it is not specific to
+AsciiDoc, it will break formatting elements.
 Use sparingly and explicitly, on ranges of text.
 
 Full stops are line breaks::

--- a/pages/visual_studio.adoc
+++ b/pages/visual_studio.adoc
@@ -5,10 +5,12 @@ category: Toolchain
 description: How to use Visual Studio, with either MSVC or clang for OS development.
 ---
 
-This page describes how to use Visual Studio as an IDE and build system for OS development. It is recommended that you use the clang toolchain, but using Microsoft's native MSVC compiler is possible as well.
+This page describes how to use *Visual Studio* as an IDE and build system for OS
+development.
+It is recommended that you use the clang toolchain, but using Microsoft's
+native MSVC compiler is possible as well.
 
 == Using clang and cmake with Visual Studio
-
 TODO
 
 == Using MSVC/msbuild with Visual Studio
@@ -16,11 +18,16 @@ TODO
 [CAUTION]
 .MSVC for OSDev
 ====
-It is possible to use MSVC for OS development, but it is heavily advised against for a number of reasons.
+It is possible to use MSVC for OS development, but it is heavily advised
+against for a number of reasons.
 
 * It is proprietary and not properly documented.
-* It's difficult and sometimes impossible to do certain things required for OS development using a pure MS toolchain.
+
+* It is difficult and sometimes impossible to do certain things required for OS
+  development using a pure MS toolchain.
+
 * Few people will be willing to give you help if something goes wrong.
 ====
 
-If you insist on using the Microsoft toolchain to build your OS, someday this page may contain information on how to use it.
+If you insist on using the Microsoft toolchain to build your OS, someday this
+page may contain information on how to use it.

--- a/pages/visual_studio.adoc
+++ b/pages/visual_studio.adoc
@@ -14,7 +14,6 @@ native MSVC compiler is possible as well.
 TODO
 
 == Using MSVC/msbuild with Visual Studio
-
 [CAUTION]
 .MSVC for OSDev
 ====
@@ -22,10 +21,8 @@ It is possible to use MSVC for OS development, but it is heavily advised
 against for a number of reasons.
 
 * It is proprietary and not properly documented.
-
 * It is difficult and sometimes impossible to do certain things required for OS
   development using a pure MS toolchain.
-
 * Few people will be willing to give you help if something goes wrong.
 ====
 

--- a/pages/visual_studio.adoc
+++ b/pages/visual_studio.adoc
@@ -2,15 +2,15 @@
 title: Visual Studio
 tags: compiler, msvc, toolchain
 category: Toolchain
-description: How to use Visual Studio, with either MSVC or clang for OS development.
+description: How to use Visual Studio, with either MSVC or Clang for OS development.
 ---
 
 This page describes how to use *Visual Studio* as an IDE and build system for OS
 development.
-It is recommended that you use the clang toolchain, but using Microsoft's
+It is recommended that you use the Clang toolchain, but using Microsoft's
 native MSVC compiler is possible as well.
 
-== Using clang and cmake with Visual Studio
+== Using Clang and cmake with Visual Studio
 TODO
 
 == Using MSVC/msbuild with Visual Studio

--- a/pages/visual_studio.adoc
+++ b/pages/visual_studio.adoc
@@ -7,13 +7,13 @@ description: How to use Visual Studio, with either MSVC or Clang for OS developm
 
 This page describes how to use *Visual Studio* as an IDE and build system for OS
 development.
-It is recommended that you use the Clang toolchain, but using Microsoft's
-native MSVC compiler is possible as well.
+The use of the Clang toolchain is recommended, but using Microsoft's native
+MSVC compiler is possible as well.
 
-== Using Clang and cmake with Visual Studio
-TODO
+// == Using Clang and cmake with Visual Studio
+// TODO
 
-== Using MSVC/msbuild with Visual Studio
+== Using MSVC and msbuild with Visual Studio
 [CAUTION]
 .MSVC for OSDev
 ====
@@ -23,8 +23,5 @@ against for a number of reasons.
 * It is proprietary and not properly documented.
 * It is difficult and sometimes impossible to do certain things required for OS
   development using a pure MS toolchain.
-* Few people will be willing to give you help if something goes wrong.
+* Few people will be willing to provide help when something goes wrong.
 ====
-
-If you insist on using the Microsoft toolchain to build your OS, someday this
-page may contain information on how to use it.

--- a/pages/writer_tutorial.adoc
+++ b/pages/writer_tutorial.adoc
@@ -29,8 +29,8 @@ Categories are defined in a YAML-formatted category description mapping in the
 We use https://github.com/asciidoctor/asciidoctor-bibtex[asciidoctor-bibtex] to
 emit bibliographies and references on the wiki.
 If you wish to cite something, first check whether `sources.bib` in the root of
-the repository has the document you wish to cite and if it's metadata is
-correct, if your entry isn't present, or is incorrect, please update it.
+the repository has the document you wish to cite and if its metadata is
+correct, if your entry is not present, or is incorrect, please update it.
 
 When adding references to a page, please add the following to the end of the
 document in order to render its bibliography:

--- a/pages/x86.adoc
+++ b/pages/x86.adoc
@@ -11,14 +11,12 @@ Intelfootnote:[https://www.intel.com/content/www/us/en/developer/articles/techni
 The iterations of the ISA can be broadly classified by integer width:
 
 * 16-bit x86, also referred to as x86_16 or IA-16 (introduced with the Intel
-8086 in 1978)
-
+  8086 in 1978)
 * 32-bit x86, also referred to as x86_32 or IA-32 (introduced with the Intel
-386 in 1985)
-
+  386 in 1985)
 * 64-bit x86 (not to be confused with IA-64), also referred to as x86_64, AMD64
-or x64.
-It is also referred to as EM64T, IA-32e or Intel64 by Intel.
+  or x64.
+  It is also referred to as EM64T, IA-32e or Intel64 by Intel.
 
 == History
 The first iteration of the x86 architecture was introduced in 1978 with the
@@ -55,9 +53,7 @@ four gigabytes of RAM.
 In 1989, the Intel 486 was introduced, with new features, such as:
 
 - An integrated "x87" FPU
-
 - L1 cache used for increased IPC
-
 - System management capabilities
 
 To this day, every properly-implemented x86 processor has backwards

--- a/pages/x86.adoc
+++ b/pages/x86.adoc
@@ -63,11 +63,11 @@ In 1989, the Intel 486 was introduced, with new features, such as:
 To this day, every properly-implemented x86 processor has backwards
 compatibility, all the way back to the original Intel 8086.
 
-== Operating Modes
+== Operating modes
 
 x86 has a handful of operating modes, used for backwards compatibility.
 
-=== Real Mode
+=== Real mode
 Real mode is the operating mode that an x86 processor boots into. It mostly
 models the original 16-bit 8086 processor, with a few extensions.
 
@@ -77,7 +77,7 @@ memory.
 
 Real mode contains no access rings or protection of any kind.
 
-=== Protected Mode (16-bit)
+=== Protected mode (16-bit)
 16-bit protected mode runs with 16-bit data and instructions, but segment
 offset registers are replaced with segment selector registers, which point to
 an entry into the 16-bit GDT.
@@ -87,7 +87,7 @@ Programs written for real mode may have a handful of compatibility issues with
 
 16-bit protected mode is rarely used.
 
-=== Protected Mode (32-bit)
+=== Protected mode (32-bit)
 32-bit protected mode reads and addresses with 32-bit values. This is the mode
 commonly referred to as "protected mode".
 Protected mode mandates a 32-bit before entry.
@@ -99,12 +99,12 @@ However, with PAE paging extensions, the virtual address space can be mapped to
 64-bit physical addresses, theoretically allowing up to 16PiB of physical
 memory to be addressed.
 
-=== Compatibility Mode (x86-64 only)
+=== Compatibility mode (x86-64 only)
 Compatibility mode runs during the transition from protected mode to long mode.
 Compatibility mode runs similarly to protected mode, and is used to allow
 64-bit structures to be loaded before entering proper long mode.
 
-=== Long Mode (x86-64 only)
+=== Long mode (x86-64 only)
 Long mode handles data up to 64 bits in general purpose registers, with
 extensions that allow for the handling of up to 512 bits of data at a time.
 Addressing in long mode is 64-bit, theoretically allowing for up to 16PiB of

--- a/pages/x86.adoc
+++ b/pages/x86.adoc
@@ -5,86 +5,177 @@ category: x86
 description: Description and brief history of the x86 CPU architecture.
 ---
 
-== Overview
-x86 is a complex-instruction-set, little-endian, 32-bit/64-bit instruction set architecture (ISA) introduced in 1985 by Intelfootnote:[https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html]. It was preceded by the Intel 8086 architecture, a 16-bit CPU architecture from 1978.
+*x86* is a backwards compatible family of little-endian, complex instruction
+set architectures (ISA) introduced in 1978 by
+Intelfootnote:[https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html].
+The iterations of the ISA can be broadly classified by integer width:
+
+* 16-bit x86, also referred to as x86_16 or IA-16 (introduced with the Intel
+8086 in 1978)
+
+* 32-bit x86, also referred to as x86_32 or IA-32 (introduced with the Intel
+386 in 1985)
+
+* 64-bit x86 (not to be confused with IA-64), also referred to as x86_64, AMD64
+or x64.
+It is also referred to as EM64T, IA-32e or Intel64 by Intel.
 
 == History
-In 1984, Intel announced the Intel 80386 architecture (later renamed x86). The first processor to implement the full architecture was the Intel 386 in 1985. In 1989, the Intel 486 was introduced, with new features, such as:
+The first iteration of the x86 architecture was introduced in 1978 with the
+8086.
+The 8086 was a 16-bit CPU, with 16-bit registers, a 16-bit data bus and a
+20-bit address bus.
+Thus it was able to address one megabyte of RAM.
+Slightly later, the 8088 CPU was introduced, which was internally identical to
+the 8086, but had a 8-bit data bus.
+The 8088 was used by the original IBM PC, introduced in 1981, which was the
+predecessor of all modern PCs.
+Thus, the x86 architecture became the dominant architecture on personal
+computers.
 
- - An integrated "x87" FPU
- - L1 cache used for increased IPC
- - System management capabilities
+In 1982, Intel introduced the 186, 188 and 286.
+The 186 and 188 where similar to the 8086 and 8088 respectively, but where
+intended for embedded systems, and included peripheral that were not compatible
+with IBM PCs.
+The Intel 286, however, was intended for multi-user, multitasking environments.
+Thus the 286 introduced features for multitasking and memory protection and was
+able to address up to 16 megabytes of RAM.
+To preserve compatibility with the 8086, most of the features introduced with
+the 286 could only be used in a mode called *protected mode*.
+The 286 and most subsequent x86 processors start in *real mode*, which emulates
+the behavior of a 8086.
+The 286 started to gain wide adoption with the introduction of the IBM AT in
+1984.
 
-To this day, every properly-implemented x86 processor has backwards compatibility, all the way back to the original Intel 8086.
+In 1985, Intel introduced the 386.
+This new interation introduced support for 32-bit integers and extended
+protected mode to introduce, among other things, paging and support for up to
+four gigabytes of RAM.
+
+In 1989, the Intel 486 was introduced, with new features, such as:
+
+- An integrated "x87" FPU
+
+- L1 cache used for increased IPC
+
+- System management capabilities
+
+To this day, every properly-implemented x86 processor has backwards
+compatibility, all the way back to the original Intel 8086.
 
 == Operating Modes
 
 x86 has a handful of operating modes, used for backwards compatibility.
 
 === Real Mode
-Real mode is the operating mode that an x86 processor boots into. It mostly models the original 16-bit 8086 processor, with a few extensions.
+Real mode is the operating mode that an x86 processor boots into. It mostly
+models the original 16-bit 8086 processor, with a few extensions.
 
-While data can be handled 16 bits at a time, segment offset registers offer addressing up to 21 bits, which provides the processor with 1MiB of addressable memory.
+While data can be handled 16 bits at a time, segment offset registers offer
+addressing up to 21 bits, which provides the processor with 1MiB of addressable
+memory.
 
 Real mode contains no access rings or protection of any kind.
 
 === Protected Mode (16-bit)
-16-bit protected mode runs with 16-bit data and instructions, but segment offset registers are replaced with segment selector registers, which point to an entry into the 16-bit GDT.
+16-bit protected mode runs with 16-bit data and instructions, but segment
+offset registers are replaced with segment selector registers, which point to
+an entry into the 16-bit GDT.
 
-Programs written for real mode may have a handful of compatibility issues with 16-bit protected mode, but instructions are still read in the same format.
+Programs written for real mode may have a handful of compatibility issues with
+16-bit protected mode, but instructions are still read in the same format.
 
 16-bit protected mode is rarely used.
 
 === Protected Mode (32-bit)
-32-bit protected mode reads and addresses with 32-bit values. This is the mode commonly referred to as "protected mode". Protected mode mandates a 32-bit before entry. Protected mode is officially entered when a far jump is performed that sets CS to an offset which points to a code segment in a 32-bit GDT.
+32-bit protected mode reads and addresses with 32-bit values. This is the mode
+commonly referred to as "protected mode".
+Protected mode mandates a 32-bit before entry.
+Protected mode is officially entered when a far jump is performed that sets CS
+to an offset which points to a code segment in a 32-bit GDT.
 
-32 bits of addressing provide up to 4GiB of addressable virtual memory. However, with PAE paging extensions, the virtual address space can be mapped to 64-bit physical addresses, theoretically allowing up to 16PiB of physical memory to be addressed.
+32 bits of addressing provide up to 4GiB of addressable virtual memory.
+However, with PAE paging extensions, the virtual address space can be mapped to
+64-bit physical addresses, theoretically allowing up to 16PiB of physical
+memory to be addressed.
 
 === Compatibility Mode (x86-64 only)
-Compatibility mode runs during the transition from protected mode to long mode. Compatibility mode runs similarly to protected mode, and is used to allow 64-bit structures to be loaded before entering proper long mode.
+Compatibility mode runs during the transition from protected mode to long mode.
+Compatibility mode runs similarly to protected mode, and is used to allow
+64-bit structures to be loaded before entering proper long mode.
 
 === Long Mode (x86-64 only)
-Long mode handles data up to 64 bits in general purpose registers, with extensions that allow for the handling of up to 512 bits of data at a time. Addressing in long mode is 64-bit, theoretically allowing for up to 16PiB of virtual memory to be *directly* addressed.
+Long mode handles data up to 64 bits in general purpose registers, with
+extensions that allow for the handling of up to 512 bits of data at a time.
+Addressing in long mode is 64-bit, theoretically allowing for up to 16PiB of
+virtual memory to be _directly_ addressed.
 
-However, on most x86-64 processors, only 48 bits of addressing are actually implemented, with the notable exception of processors that support 5-level-paging. These 48-bit addresses must all have the top unsupported bits be set or unset, resulting in two "halves" of the virtual address space. These addresses are referred to as "canonical" addresses.
+However, on most x86-64 processors, only 48 bits of addressing are actually
+implemented, with the notable exception of processors that support 5-level
+paging.
+These 48-bit addresses must all have the top unsupported bits be set or unset,
+resulting in two "halves" of the virtual address space. These addresses are
+referred to as "canonical" addresses.
 
-The name "long mode" refers to the commonplace technical term for a 64-bit integer, a "long".
+The name "long mode" refers to the commonplace technical term for a 64-bit
+integer, a "long".
 
-Due to the unfulfillable amount of virtual memory, PAE paging is mandated in long mode. This allows for contiguous mapping of physical RAM, with memory-mapped IO out of physical RAM space. This also allows x86-64 operating systems to implement "swap memory", a process where virtual addresses point to data not in physical RAM, but rather stored on disk.
+Due to the unfulfillable amount of virtual memory, PAE paging is mandated in
+long mode.
+This allows for contiguous mapping of physical RAM, with memory-mapped IO out
+of physical RAM space.
+This also allows x86-64 operating systems to implement "swap memory", a process
+where virtual addresses point to data not in physical RAM, but rather stored on
+disk.
 
 == Extensions
-x86 processors have a plethora of extensions that expand on standard behavior. The most notable, x86-64, implements 64-bit addressing and long mode. 
+x86 processors have a plethora of extensions that expand on standard behavior.
+The most notable, x86-64, implements 64-bit addressing and long mode. 
 
-(This section only contains a handful of extensions, there are too many to list at once.)
+This section only contains a handful of extensions, there are too many to list
+at once.
 
 === x86-64
-The x86-64 extension is quite expansive, implementing the 64-bit operating mode and 64-bit addressing. It is nearly impossible to find a working computer today that does not support x86-64.
+The x86-64 extension is quite expansive, implementing the 64-bit operating mode
+and 64-bit addressing.
+It is nearly impossible to find a working computer today that does not support
+x86-64.
 
 === PAE/NX
-PAE/NX implements 4-level paging, and adds a handful of properties to pages to implement extensive memory protection, including NX, a flag to disable execution on a particular page. 
+PAE/NX implements 4-level paging, and adds a handful of properties to pages to
+implement extensive memory protection, including NX, a flag to disable
+execution on a particular page. 
 
 Most operational computers today support PAE/NX.
 
 === x87
-x87 is a floating-point calculation extension. While technically an extension, it is supported on most x86 processors.
+x87 is a floating-point calculation extension.
+While technically an extension, it is supported on most x86 processors.
 
 === SSE
-SSE is a 128-bit data extension. It adds 8-16 128-bit general purpose `XMM` registers, and instructions to perform SIMD vector math. 
+SSE is a 128-bit data extension.
+It adds 8-16 128-bit general purpose `XMM` registers, and instructions to
+perform SIMD vector math. 
 
-SSE has several versions. x86-64 processors are mandated to support at least SSE2.
+SSE has several versions. x86-64 processors are mandated to support at least
+SSE2.
 
 === AVX
-AVX is a 256-bit data extension. It performs a purpose similar to SSE, and implements a handful of 256-bit `YMM` registers.
+AVX is a 256-bit data extension. It performs a purpose similar to SSE, and
+implements a handful of 256-bit `YMM` registers.
 
-AVX was released alongside the Haswell microarchitecture in 2014. A not-insignificant number of operational computers today do not support AVX.
+AVX was released alongside the Haswell microarchitecture in 2014.
+A not-insignificant number of operational computers today do not support AVX.
 
 ==== AVX-512
-AVX-512 is not a single extension, but rather a family of extensions. It is similar to AVX, but implements a handful of 512-bit `ZMM` registers.
+AVX-512 is not a single extension, but rather a family of extensions.
+It is similar to AVX, but implements a handful of 512-bit `ZMM` registers.
 
-AVX-512 is quite new, with consumer processors supporting AVX-512 being released in 2018.footnote:[https://web.archive.org/web/20161023135525/http://www.legitreviews.com/intel-cannonlake-added-to-llvms-clang_179210] It is yet to become widely supported.
+AVX-512 is quite new, with consumer processors supporting AVX-512 being
+released in 2018.footnote:[https://web.archive.org/web/20161023135525/http://www.legitreviews.com/intel-cannonlake-added-to-llvms-clang_179210]
+It is yet to become widely supported.
 
 == See Also
-
 * https://en.wikipedia.org/wiki/X86[x86 on Wikipedia]
 * https://www.amd.com/en/support/tech-docs/amd64-architecture-programmers-manual-volumes-1-5[AMD64 Architecture Programmers' Manuals]
 * https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html[Intel Software Developer Manuals]


### PR DESCRIPTION
I was under a bit of a rush when making this contribution, so I hope there aren't major oversights:
* Reformatted most text (mainly introduction of hard wrap).
* Rewrote x86 lead and history section.
* Otherwise, didn't fix content or references (that will follow in a later PR).
* Removed links to non-existent pages (if reintroduced, should have visual indication, similar to MediaWiki redlinks).
* Updated main page.
* I didn't touched the bare bones tutorial (we have to re-evaluate that format).