### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ## The OSDev Wiki
 
-The goal of this wiki is to modernize the information found in the long-standing OSDev wiki found at [wiki.osdev.org](https://wiki.osdev.org) and to decentralize it. It is currently **WIP** and **not ready** for use.
+The goal of this wiki is to create a decentralized repository of accurate and
+up-to-date information on operating system development. It is currently **WIP**
+and **not ready** for use.
 
 This wiki is not endorsed by, does not have any connection to, and is not related in any way with another wiki found at [wiki.osdev.org](https://wiki.osdev.org).
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 ## The OSDev Wiki
 
 The goal of this wiki is to create a decentralized repository of accurate and
-up-to-date information on operating system development. It is currently **WIP**
-and **not ready** for use.
+up-to-date information on operating system development.
+It is currently **WIP** and **not ready** for use.
 
-This wiki is not endorsed by, does not have any connection to, and is not related in any way with another wiki found at [wiki.osdev.org](https://wiki.osdev.org).
+This wiki is not endorsed by, does not have any connection to, and is not
+related in any way with another wiki found at
+[wiki.osdev.org](https://wiki.osdev.org).
 
 # Contributing
 
@@ -21,13 +23,16 @@ The project has some non-Haskell dependencies:
 
 ## Building and running
 
-Because building the Haskell dependecies takes a long time, we recommend using our Nix binary cache to get all the dependecies without building. (~10 min setup time)
+Because building the Haskell dependencies takes a long time, we recommend using
+our Nix binary cache to get all the dependencies without building (~10 min
+setup time).
 
 ### With Nix
 
 [Install nix](https://nixos.org/download.html#download-nix).
 
-Edit the configuration file added by Nix at `/etc/nix/nix.conf` and add these two lines to setup the binary cache:
+Edit the configuration file added by Nix at `/etc/nix/nix.conf` and add these
+two lines to setup the binary cache:
 
 ```nix
 trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= osdev-wiki-cache-2:xnfH8Tkm0Sp5c8dDxpuFE0/w1PB6E4NUxjcnShNdkZ0=
@@ -50,7 +55,8 @@ cd ..
 
 ### Building locally
 
-**Alternatively**, you can build locally (~1 hour build time). You do _not_ need to do this if you have done the Nix setup above.
+**Alternatively**, you can build locally (~1 hour build time). You do _not_
+need to do this if you have done the Nix setup above.
 
 You will need to have Stack installed to compile and run the main binary.
 
@@ -69,4 +75,6 @@ stack run --cwd .. watch
 
 ## Writing content
 
-All content can be found in `pages/`. You can find our [quick guide here](https://osdev.wiki/pages/writer_tutorial.html) to learn the basics (~2 min reading).
+All content can be found in `pages/`.
+You can find our [quick guide here](https://osdev.wiki/pages/writer_tutorial.html)
+to learn the basics (~2 min reading).

--- a/index.adoc
+++ b/index.adoc
@@ -5,9 +5,8 @@ description: The place to start for operating system development in the 2020s.
 
 Welcome to *osdev.wiki*!
 
-The goal of this wiki is to modernize the information found in the long-standing
-OSDev wiki found at https://wiki.osdev.org[wiki.osdev.org] and to decentralize
-it.
+The goal of this wiki is to create a decentralized repository of accurate and
+up-to-date information on operating system development.
 This site is currently *WIP* and very incomplete, thus contributions are
 welcome!
 

--- a/pages/calling_conventions.adoc
+++ b/pages/calling_conventions.adoc
@@ -8,18 +8,18 @@ description: Examples of calling conventions on common platforms.
 
 A *calling convention* is the set of contracts that compiler-generated machine
 code respects and expects external functions to respect.
-The calling convention specifies, for example
+Among other things, the calling convention specifies:
 
-- how parameters are passed to functions
+- how parameters are passed to functions;
 - how the stack is handled and cleaned (for example if needs to be aligned at
-  function entry)
-- how structures are going to be laid out in memory
-- which registers need to be restored by the caller and which by the callee
+  function entry);
+- how structures are going to be laid out in memory;
+- which registers need to be restored by the caller and which by the callee.
 
 == x86-64 calling conventions
 The Windows (including UEFI) world and the UNIX (Linux, macOS, BSDs) world have
-adopted two different conventions. Note that MSVC can only generate code using
-the Windows calling convention.
+adopted two different conventions.
+Note that MSVC can only generate code using the Windows calling convention.
 
 === Microsoft x64
 The x64 Application Binary Interfacefootnote:[https://github.com/MicrosoftDocs/cpp-docs/blob/main/docs/build/x64-calling-convention.md]
@@ -34,13 +34,13 @@ be passed by reference.
 A single argument is never spread across multiple registers.
 
 The x87 register stack is unused.
-It may be used by the callee, but consider it volatile across function calls.
+It may be used by the callee, but is considered volatile across function calls.
 All floating point operations are done using the 16 XMM registers.
 
-Integer arguments are passed in registers RCX, RDX, R8, and R9. Floating point
+Integer arguments are passed in registers RCX, RDX, R8, and R9; floating point
 arguments are passed in XMM0L, XMM1L, XMM2L, and XMM3L.
-16-byte arguments are passed by reference. Parameter passing is described in
-detail in Parameter passing.
+16-byte arguments are passed by reference.
+Parameter passing is described in detail in the parameter section.
 These registers, and RAX, R10, R11, XMM4, and XMM5, are considered volatile.
 
 ==== Register allocation
@@ -87,9 +87,9 @@ A function calling this needs to have at least 56 bytes of stack to store the
 parameters and home space and ensure that the stack is aligned after the `CALL`.
 
 ==== Return value
-If the return value is an integer/struct/union whose size is less than or equal
-to 64 bits, it is returned in RAX; otherwise, the struct is allocated by the
-caller and a pointer to it is passed as the first parameter.
+If the return value is an integer, struct, or union whose size is less than or
+equal to 64 bits, it is returned in RAX; otherwise, the struct is allocated by
+the caller, and a pointer to it is passed as the first parameter.
 
 [source,c]
 ---
@@ -155,11 +155,11 @@ A function calling this needs to have at least 32 bytes of stack to store the
 parameters and align the stack upon call.
 
 ==== Return value
-If the return value is an integer/struct/union whose size is less than or equal
-than 64 bits, it is returned in `RAX`; otherwise, the struct is allocated by the
-caller and a pointer to it is passed as the first parameter, similarly to the
+If the return value is an integer, struct, or union whose size is less than or
+equal than 64 bits, it is returned in `RAX`; otherwise, the struct is allocated
+by the caller and a pointer to it is passed as the first parameter, like the
 Microsoft x64 ABI.
-Dissimilarly, the pointer is actually returned in `RAX` upon return.
+Unlike the Microsoft ABI, the pointer is actually returned in `RAX` upon return.
 
 [source,c]
 ---


### PR DESCRIPTION
Fixed some minor things I noticed while reading certain parts of the wiki. The calling conventions article is, of course, still far from perfect.
The more substantive change is rephrasing the paragraph introducing the wiki. The rationale for this is that it might encourage people to copy stuff from the other wiki, which often yields suboptimal results.